### PR TITLE
Added PlayerAdvertiseEvent and fixed tab complete from "<time>" to "<description>"

### DIFF
--- a/src/main/java/me/serbob/toastedad/Commands/AD.java
+++ b/src/main/java/me/serbob/toastedad/Commands/AD.java
@@ -1,6 +1,7 @@
 package me.serbob.toastedad.Commands;
 
 import me.serbob.toastedad.ToastedAD;
+import me.serbob.toastedad.Events.PlayerAdvertiseEvent;
 import me.serbob.toastedad.Utils.ToastedUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -85,6 +86,12 @@ public class AD implements CommandExecutor {
         playerTime.putIfAbsent(player, shortestTime(player));
         playAdvertiseSound();
         String message = buildMessage(args);
+
+        // Create and call the PlayerAdvertiseEvent
+        PlayerAdvertiseEvent event = new PlayerAdvertiseEvent(player, message);
+        Bukkit.getServer().getPluginManager().callEvent(event);
+
+        // Broadcasting the advertisement
         broadcastAdvertiseMessage(player, message);
     }
 

--- a/src/main/java/me/serbob/toastedad/Events/PlayerAdvertiseEvent.java
+++ b/src/main/java/me/serbob/toastedad/Events/PlayerAdvertiseEvent.java
@@ -1,0 +1,33 @@
+package me.serbob.toastedad.Events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerAdvertiseEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private final Player player;
+    private final String message;
+
+    public PlayerAdvertiseEvent(Player player, String message) {
+        this.player = player;
+        this.message = message;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/me/serbob/toastedad/TabCompleter/ADTC.java
+++ b/src/main/java/me/serbob/toastedad/TabCompleter/ADTC.java
@@ -12,7 +12,7 @@ public class ADTC implements TabCompleter {
     public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
         List<String> list = new ArrayList<>();
         if(args.length<2) {
-            list.add("<time>");
+            list.add("<description>");
         }
         return list;
     }


### PR DESCRIPTION
Hello, I added the PlayerAdvertiseEvent that is sent when a player runs an ad, this can be used to create an alert like below, and also fixed the tab complete which showed "time" to "description".
![image](https://github.com/SerbanHiro/ToastedAD/assets/63890666/defad55c-8e7f-4827-bf27-565c36a8d386)
